### PR TITLE
[Chore] Standardize `dotnet-lint` hook names

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/pre-commit-hooks.json
-- id: dotnet-format
-  name: Format dotnet files
+- id: dotnet-lint-fix
+  name: Lint dotnet (Fix)
   description: Run the "dotnet format" command, fixing any issues.
   entry: dotnet format
   language: system
@@ -8,7 +8,7 @@
     - c#
   pass_filenames: false
 - id: dotnet-lint
-  name: Lint dotnet files
+  name: Lint dotnet
   description: Run the "dotnet format" command, verifying there would be no changes made.
   entry: dotnet format --verify-no-changes
   language: system


### PR DESCRIPTION
This will be a breaking change.